### PR TITLE
Linux support

### DIFF
--- a/21.02/conanfile.py
+++ b/21.02/conanfile.py
@@ -70,6 +70,7 @@ class USDConan(ConanFile):
             return self._cmake
         self._cmake = CMake(self)
 
+        self._cmake.definitions["CMAKE_POSITION_INDEPENDENT_CODE"] = True
         self._cmake.definitions["PXR_STRICT_BUILD_MODE"] = False
         self._cmake.definitions["PXR_VALIDATE_GENERATED_CODE"] = False
         self._cmake.definitions["PXR_HEADLESS_TEST_MODE"] = True
@@ -101,7 +102,7 @@ class USDConan(ConanFile):
         self._cmake.definitions["PXR_ENABLE_METAL_SUPPORT"] = False
         self._cmake.definitions["PXR_ENABLE_VULKAN_SUPPORT"] = False
         self._cmake.definitions["PXR_ENABLE_GL_SUPPORT"] = False
-        self._cmake.definitions["PXR_ENABLE_PRECOMPILED_HEADERS"] = True
+        self._cmake.definitions["PXR_ENABLE_PRECOMPILED_HEADERS"] = False
         self._cmake.definitions["BUILD_SHARED_LIBS"] = True
         self._cmake.definitions["PXR_BUILD_MONOLITHIC"] = False
 

--- a/21.02/conanfile.py
+++ b/21.02/conanfile.py
@@ -63,6 +63,8 @@ class USDConan(ConanFile):
         #tools.untargz("C:\\Users\\TM-Z8\\Downloads\\USD-21.02.tar.gz")
         tools.patch(patch_file="patches/USD-21.02.patch",
                     base_path="USD-{}".format(self.version))
+        tools.patch(patch_file="patches/USD-21.02-tf-token-algorithm.patch",
+                    base_path="USD-{}".format(self.version))
         os.rename("USD-{}".format(self.version), self._source_subfolder)
 
     def _configure_cmake(self):

--- a/21.02/patches/USD-21.02-tf-token-algorithm.patch
+++ b/21.02/patches/USD-21.02-tf-token-algorithm.patch
@@ -1,0 +1,11 @@
+diff -Naur a/pxr/base/tf/token.cpp b/pxr/base/tf/token.cpp
+--- USD-21.02_compare/pxr/base/tf/token.cpp	2021-06-11 01:29:31.942639200 -0700
++++ USD-21.02/pxr/base/tf/token.cpp	2021-06-11 01:30:32.327174400 -0700
+@@ -39,6 +39,7 @@
+ 
+ #include <tbb/spin_mutex.h>
+ 
++#include <algorithm>
+ #include <string>
+ #include <ostream>
+ #include <vector>

--- a/21.02/patches/USD-21.02-tf-token-algorithm.patch
+++ b/21.02/patches/USD-21.02-tf-token-algorithm.patch
@@ -9,3 +9,15 @@ diff -Naur a/pxr/base/tf/token.cpp b/pxr/base/tf/token.cpp
  #include <string>
  #include <ostream>
  #include <vector>
+diff -Naur a/pxr/base/trace/eventTreeBuilder.cpp b/pxr/base/trace/eventTreeBuilder.cpp
+--- a/pxr/base/trace/eventTreeBuilder.cpp	2021-06-11 01:29:30.948038800 -0700
++++ b/pxr/base/trace/eventTreeBuilder.cpp	2021-06-11 01:37:48.887415500 -0700
+@@ -28,6 +28,8 @@
+ 
+ #include "pxr/base/trace/trace.h"
+ 
++#include <algorithm>
++
+ PXR_NAMESPACE_OPEN_SCOPE
+ 
+ Trace_EventTreeBuilder::Trace_EventTreeBuilder() 

--- a/21.02/patches/USD-21.02-tf-token-algorithm.patch
+++ b/21.02/patches/USD-21.02-tf-token-algorithm.patch
@@ -21,3 +21,25 @@ diff -Naur a/pxr/base/trace/eventTreeBuilder.cpp b/pxr/base/trace/eventTreeBuild
  PXR_NAMESPACE_OPEN_SCOPE
  
  Trace_EventTreeBuilder::Trace_EventTreeBuilder() 
+diff -Naur a/pxr/usd/sdr/shaderMetadataHelpers.cpp b/pxr/usd/sdr/shaderMetadataHelpers.cpp
+--- a/pxr/usd/sdr/shaderMetadataHelpers.cpp	2021-06-11 01:29:23.607791000 -0700
++++ b/pxr/usd/sdr/shaderMetadataHelpers.cpp	2021-06-11 01:46:26.988923000 -0700
+@@ -27,6 +27,7 @@
+ #include "pxr/usd/sdr/shaderMetadataHelpers.h"
+ #include "pxr/usd/sdr/shaderProperty.h"
+ 
++#include <algorithm>
+ #include <iostream>
+ 
+ PXR_NAMESPACE_OPEN_SCOPE
+diff -Naur a/pxr/usd/sdr/shaderNode.cpp b/pxr/usd/sdr/shaderNode.cpp
+--- a/pxr/usd/sdr/shaderNode.cpp	2021-06-11 01:29:23.607791000 -0700
++++ b/pxr/usd/sdr/shaderNode.cpp	2021-06-11 01:47:00.087325300 -0700
+@@ -28,6 +28,7 @@
+ #include "pxr/usd/sdr/shaderNode.h"
+ #include "pxr/usd/sdr/shaderProperty.h"
+ 
++#include <algorithm>
+ #include <unordered_set>
+ 
+ PXR_NAMESPACE_OPEN_SCOPE

--- a/21.02/patches/USD-21.02-tf-token-algorithm.patch
+++ b/21.02/patches/USD-21.02-tf-token-algorithm.patch
@@ -1,6 +1,6 @@
 diff -Naur a/pxr/base/tf/token.cpp b/pxr/base/tf/token.cpp
---- USD-21.02_compare/pxr/base/tf/token.cpp	2021-06-11 01:29:31.942639200 -0700
-+++ USD-21.02/pxr/base/tf/token.cpp	2021-06-11 01:30:32.327174400 -0700
+--- a/pxr/base/tf/token.cpp	2021-06-11 01:29:31.942639200 -0700
++++ b/pxr/base/tf/token.cpp	2021-06-11 01:30:32.327174400 -0700
 @@ -39,6 +39,7 @@
  
  #include <tbb/spin_mutex.h>

--- a/21.02/test_package/CMakeLists.txt
+++ b/21.02/test_package/CMakeLists.txt
@@ -5,4 +5,4 @@ find_package(usd REQUIRED)
 
 add_executable(example example.cpp)
 target_link_libraries(example PUBLIC usd::usd)
-target_compile_features(example PUBLIC cxx_std_14)
+#target_compile_features(example PUBLIC cxx_std_14)

--- a/21.02/test_package/example.cpp
+++ b/21.02/test_package/example.cpp
@@ -7,7 +7,7 @@
 
 // pxrInternal_v0_21__pxrReserved__::UsdStage::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, pxrInternal_v0_21__pxrReserved__::UsdStage::InitialLoadSet)
 //
-//#include <iostream>
+#include <iostream>
 //#include <string>
 
 int main(int argc, char *argv[]) {

--- a/21.02/test_package/example.cpp
+++ b/21.02/test_package/example.cpp
@@ -5,8 +5,10 @@
 #include "pxr/usd/usdGeom/mesh.h"
 #include "pxr/usd/usdGeom/points.h"
 
-#include <iostream>
-#include <string>
+// pxrInternal_v0_21__pxrReserved__::UsdStage::Open(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, pxrInternal_v0_21__pxrReserved__::UsdStage::InitialLoadSet)
+//
+//#include <iostream>
+//#include <string>
 
 int main(int argc, char *argv[]) {
   if (argc != 2) {


### PR DESCRIPTION
It's important to make sure on linux that the compiler c++ option is set to stdc++11, like so:

```
[settings]
os=Linux
os_build=Linux
arch=x86_64
arch_build=x86_64
compiler=gcc
compiler.version=9
compiler.libcxx=libstdc++11
build_type=Release
[options]
[build_requires]
[env]
```
